### PR TITLE
fix(website): ensure long notes do not go above the card border

### DIFF
--- a/website/src/components/__tests__/algorithm-detail-modal.test.tsx
+++ b/website/src/components/__tests__/algorithm-detail-modal.test.tsx
@@ -57,6 +57,16 @@ const mockAlgorithms = [
   },
 ];
 
+const mockAlgorithmsWithLongNote = [
+  {
+    title: "Algo 1",
+    notes: "longword".repeat(50),
+    link: "link1",
+    language: "Java",
+    type: "algorithm",
+  },
+];
+
 describe("AlgorithmDetailModal", () => {
   const defaultProps = {
     isOpen: true,
@@ -146,5 +156,15 @@ describe("AlgorithmDetailModal", () => {
     // Check if the icon is rendered with the correct class
     const languageBadge = screen.getByTestId("main-language-badge");
     expect(languageBadge.querySelector("i")).toHaveClass("icon-Java");
+  });
+
+  it("should have break-words class for long notes", () => {
+    const props = {
+      ...defaultProps,
+      algorithms: mockAlgorithmsWithLongNote,
+    };
+    render(<AlgorithmDetailModal {...props} />);
+    const notes = screen.getByText("longword".repeat(50));
+    expect(notes).toHaveClass("break-words");
   });
 });

--- a/website/src/components/algorithm-detail-modal.tsx
+++ b/website/src/components/algorithm-detail-modal.tsx
@@ -188,7 +188,7 @@ export function AlgorithmDetailModal({
                     <Separator />
 
                     <div className="prose prose-sm max-w-none">
-                      <p className="text-muted-foreground leading-relaxed whitespace-pre-wrap text-sm sm:text-base">
+                      <p className="text-muted-foreground leading-relaxed whitespace-pre-wrap text-sm sm:text-base break-words">
                         {currentAlgorithm.notes}
                       </p>
                     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Long notes in the Algorithm Detail modal now wrap within the container to prevent overflow and maintain layout across screen sizes, improving readability.
- Tests
  - Added automated test to verify word-breaking behavior for lengthy notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->