### PR TITLE
feat(parser): extract reference from commits

### DIFF
--- a/docs/adrs/0001-implement-reference-parsing.md
+++ b/docs/adrs/0001-implement-reference-parsing.md
@@ -1,0 +1,34 @@
+# ADR 0001: Implement Reference Parsing from Commits
+
+*   **Date**: 2025-09-26
+*   **Status**: Approved
+
+## Context
+
+The Kaizen project currently parses commit messages to extract information about completed algorithm and system design challenges. This information is then displayed on the website.
+
+Users have requested the ability to include a reference link in their commit messages and have this link be easily accessible on the website. This would allow them to link to the problem description, a discussion forum, or any other relevant resource.
+
+## Decision
+
+We will implement a new feature to parse a `Ref.:` field from the commit message and display it as a "Reference" button on the website.
+
+This will involve the following changes:
+
+1.  **`kaizen-parser`**:
+    *   Update the commit message parsing logic in `parser.rs` to extract the URL from the `Ref.:` field.
+    *   Add a new `reference` field to the `CommitData` struct in `commit.rs`.
+
+2.  **`website`**:
+    *   Update the `Timeline.tsx` component to display a "Reference" button next to the "Code" button for each algorithm entry.
+    *   Update the `AlgorithmDetailModal.tsx` component to include the "Reference" button in the modal view.
+    *   Update the `kaizen-data.ts` interface to include the new `reference` field.
+
+## Consequences
+
+*   **Pros**:
+    *   Users will be able to easily access relevant resources for each algorithm.
+    *   The project will be more useful as a personal learning journal.
+*   **Cons**:
+    *   This will require changes to both the parser and the website.
+    *   The commit message format will be slightly more complex.

--- a/kaizen-parser/src/domain/commit.rs
+++ b/kaizen-parser/src/domain/commit.rs
@@ -4,11 +4,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct CommitData {
-	pub title:    String,
-	pub notes:    String,
-	pub link:     String,
-	pub language: String,
-	pub type_of:  String,
+	pub title:     String,
+	pub notes:     String,
+	pub link:      String,
+	pub language:  String,
+	pub type_of:   String,
+	pub reference: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/kaizen-parser/src/domain/stats.rs
+++ b/kaizen-parser/src/domain/stats.rs
@@ -96,11 +96,12 @@ mod tests {
 
 	fn create_commit_data(language: &str) -> CommitData {
 		CommitData {
-			title:    "Test".to_string(),
-			notes:    "Test notes".to_string(),
-			link:     "http://example.com".to_string(),
-			language: language.to_string(),
-			type_of:  "algo".to_string(),
+			title:     "Test".to_string(),
+			notes:     "Test notes".to_string(),
+			link:      "http://example.com".to_string(),
+			language:  language.to_string(),
+			type_of:   "algo".to_string(),
+			reference: None,
 		}
 	}
 

--- a/kaizen-parser/tests/test_json_file_output_writer.rs
+++ b/kaizen-parser/tests/test_json_file_output_writer.rs
@@ -18,11 +18,12 @@ fn test_json_file_output_writer() -> Result<(), io::Error> {
 
 	let mut commits: HashMap<String, Vec<CommitData>> = HashMap::new();
 	commits.insert("2025-01-01".to_string(), vec![CommitData {
-		title:    "Test Title".to_string(),
-		notes:    "Test notes.".to_string(),
-		link:     "http://example.com".to_string(),
-		language: "Rust".to_string(),
-		type_of:  "algo".to_string(),
+		title:     "Test Title".to_string(),
+		notes:     "Test notes.".to_string(),
+		link:      "http://example.com".to_string(),
+		language:  "Rust".to_string(),
+		type_of:   "algo".to_string(),
+		reference: None,
 	}]);
 
 	let mut stats = KaizenStats {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for commit reference links: commits with a "Ref." URL now surface a Reference button in timeline entries and detail views, letting users open associated references from the website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->