### PR TITLE
perf(parser): aggregate data by date in parallel

### DIFF
--- a/kaizen-parser/justfile
+++ b/kaizen-parser/justfile
@@ -1,3 +1,6 @@
+build:
+  cargo build --release --locked --no-default-features
+
 test:
 	cargo tarpaulin --out Lcov --all-features
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved commit parsing/aggregation: results are grouped by date and now preserve original commit order within each day for more consistent outputs.
* **Bug Fixes**
  * Reference links are detected as full URLs and removed from notes, yielding cleaner, trimmed note text.
* **Chores**
  * Added build/test/format/lint targets to project tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->