### PR TITLE
fix(website): prevent from rendering backsticks on inline code in the solution page

### DIFF
--- a/website/e2e-tests/solution.spec.ts
+++ b/website/e2e-tests/solution.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "./_shared/fixtures";
+
+test.describe("Solution Page", () => {
+  test("should render inline code correctly without raw backticks", async ({
+    page,
+  }) => {
+    // This page's analysis has `RandomWord.java` in backticks.
+    await page.goto("/solution/2025-09-14/0");
+
+    // The raw markdown with backticks should not be found as plain text.
+    await expect(page.getByText("`RandomWord.java`")).not.toBeVisible();
+
+    // Instead, it should be rendered as a <code> element.
+    const codeElement = page.locator("code", { hasText: "RandomWord.java" });
+    await expect(codeElement.first()).toBeVisible();
+  });
+});

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -93,6 +93,10 @@
   body {
     @apply bg-background text-foreground;
   }
+  .prose code::before,
+  .prose code::after {
+    content: "" !important;
+  }
 }
 
 /* Added custom styles for language badges and heatmap */


### PR DESCRIPTION
Before
------
<img width="914" height="391" alt="analisys-before" src="https://github.com/user-attachments/assets/c9d21c5a-a961-4845-8d2e-c3bf24070a46" />


After
------
<img width="917" height="423" alt="analysis-after" src="https://github.com/user-attachments/assets/9aeda2c9-d7ec-4dfd-9c8f-d7ef502ea7c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected inline code rendering on the Solution Page so filenames and code snippets display properly without stray backticks or extra symbols.
  - Updated typography styling to prevent pseudo-element content from appearing around inline code in prose.

- Tests
  - Added an end-to-end test to verify inline code is rendered as formatted code and not as raw backticked text on the Solution Page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->